### PR TITLE
[32기 이현정]Add: 소셜로그인 카카오 토큰 받아오는 부분까지 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+
+.env
 .eslintcache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-      "editor.tabSize": 2,
-    "editor.formatOnSave": true,
-      "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true,
-    },
-      "javascript.format.enable": false,
-      "eslint.alwaysShowStatus": true,
-      "files.autoSave": "onFocusChange"
-  }
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "javascript.format.enable": false,
+  "eslint.alwaysShowStatus": true,
+  "files.autoSave": "onFocusChange",
+  "cSpell.words": ["kakao", "Loginkakao"]
+}

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Detail from './pages/Detail/Detail';
-import Login from './pages/Login/Login';
 import Main from './pages/Main/Main';
+import Detail from './pages/Detail/Detail';
 import Review from './pages/Review/Review';
+import Login from './pages/Login/Login';
+import Loginkakao from './pages/Loginkakao/Loginkakao';
 
 const Router = () => {
   return (
@@ -13,6 +14,7 @@ const Router = () => {
         <Route path="/detail/:id" element={<Detail />} />
         <Route path="/review" element={<Review />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/login/kakao" element={<Loginkakao />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { URI } from './authData';
 
 const Login = () => {
-  return <div>Login</div>;
+  return <a href={URI}>로그인</a>;
 };
 
 export default Login;

--- a/src/pages/Login/authData.js
+++ b/src/pages/Login/authData.js
@@ -1,0 +1,3 @@
+export const REST_API_KEY = process.env.REACT_APP_REST_API_KEY;
+export const REDIRECT_URI = process.env.REACT_APP_REDIRECT_URI;
+export const URI = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;

--- a/src/pages/Loginkakao/Loginkakao.js
+++ b/src/pages/Loginkakao/Loginkakao.js
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { REST_API_KEY, REDIRECT_URI } from '../Login/authData';
+
+const Loginkakao = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const authCode = location.search.split('=')[1];
+  const kakaoAccessUri = `grant_type=authorization_code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&code=${authCode}`;
+
+  useEffect(() => {
+    fetch('https://kauth.kakao.com/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+      },
+      body: kakaoAccessUri,
+    })
+      .then(res => {
+        if (res.status === 200) {
+          return res.json();
+        } else {
+          alert('통신 안된듯?');
+        }
+      })
+      .then(data => sendToken(data.access_token));
+    // .then(res => {
+    //   if (res.access_token) {
+    //     sendToken(res.access_token);
+    //   } else {
+    //     alert('연결안된듯?');
+    //   }
+    // });
+  }, []);
+
+  const sendToken = kakaoAccessToken => {
+    fetch(`http://10.58.4.175:8000/users/login/kakao`, {
+      method: 'POST',
+      headers: {
+        Authorization: kakaoAccessToken,
+      },
+    })
+      .then(res => res.json())
+      .then(res => {
+        localStorage.setItem('token', res.access_token);
+        alert('환영합니다!');
+        navigate('/');
+      });
+  };
+
+  return <div>로그인중입니다</div>;
+};
+
+export default Loginkakao;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 소셜 로그인 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Restful API , 인가 코드 받기
- 카카오 Restful API를 dotenv를 사용해서 env파일에 저장하고 .gitignore파일을 사용하여 추적하지 못하게 한다.
- CRA에 dotenv가 기본적으로 포함하고 있어서 자동으로 파일이 변환되었다.
- .js 파일에 바로 쓰는건 절대 금지!!!!
- 앞에 꼭! REACT_APP_으로 시작해야한다. 그리고 = 으로 빈칸도 없어야 한다.

2. authData.js 에서는 process.env.REACT_APP_이름을 변수명을 사용해서 만들어 두는 파일 생성
- 사용하기 편리하게 만들어 줌.

3. Loginkakao 폴더 생성 그 안에 파일 생성 
- import로  api 와 redirect_uri 받아와서 fetch 사용해서 토큰 요청
- method: POST
- code는 useLocation 사용/ location.search 는 url에 붙은 매개변수 반환한다.(물음표 뒤의 값)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 우선적으로 정식문서를 보면서 이해하기 힘들었으나, 같은 기능을 구현하는 다른 팀원이 크게 틀을 설명해 주었고, 전체적인 틀 이해하였음.
- .env 파일과 .gitignore에 적용하여 사용하는 법을 배웠다.

<br />

## :: 기타 질문 및 특이 사항
- 로직에 대한 정확한 이해 부족 
