### PR TITLE
[32기 장형원] Fix: MyPage with MockData(최종 완료)

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -7,6 +7,7 @@ import Review from './pages/Review/Review';
 import Login from './pages/Login/Login';
 import Loginkakao from './pages/Loginkakao/Loginkakao';
 import Footer from './Components/Footer/Footer';
+import MyPage from './pages/MyPage/MyPage';
 
 const Router = () => {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -20,6 +21,7 @@ const Router = () => {
         <Route path="/review" element={<Review />} />
         <Route path="/login" element={<Login />} />
         <Route path="/login/kakao" element={<Loginkakao />} />
+        <Route path="/mypage" element={<MyPage />} />
       </Routes>
       <Footer isDarkMode={isDarkMode} />
     </BrowserRouter>

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -1,0 +1,262 @@
+import React, { useState } from 'react';
+import MyReservation from './MyReservation';
+import MyReview from './MyReview';
+import PassedReservation from './PassedReservation';
+import styled from 'styled-components';
+
+const reviewData = [
+  {
+    id: '1',
+    text: '우리 아이가 정말 좋은 시설에 다녀온 것 같아요! 덕분에 오랜만에 마음 편한 여행을 다녀왔습니다.',
+    sitter: '자옥쓰',
+    date: '2022-05-13 20:12',
+  },
+  {
+    id: '2',
+    name: '김춘자',
+    text: '펫시터님께서 엄청 꼼꼼하세요! 매일마다 사진도 보내주시고 우리 아이가 잘 케어받고 있구나를 느끼게 해 주십니다.',
+    sitter: '김영광',
+    date: '2022-05-12 20:12',
+  },
+  {
+    id: '3',
+    text: '다음에 일이 생겨도 이 펫시터님께 예약할 것 같아요!',
+    sitter: '박순복',
+    date: '2022-05-10 19:12',
+  },
+  {
+    id: '4',
+    text: '벌써 네 번째 예약인데 여전히 친절하시구 좋습니다!',
+    sitter: '김예지',
+    date: '2022-05-07 20:02',
+  },
+  {
+    id: '5',
+    text: '추천합니다.',
+    sitter: '오현아',
+    date: '2022-05-01 17:28',
+  },
+];
+
+const reservationData = [
+  {
+    id: 1,
+    sittername: '장형원',
+    reservationStartDate: '2022-02-01',
+    reservationEndDate: '2022-02-03',
+    petcount: 2,
+    cancelStatus: true,
+    reservationState: 'loading',
+  },
+  {
+    id: 2,
+    sittername: '이현정',
+    reservationStartDate: '2022-12-02',
+    reservationEndDate: '2022-12-03',
+    petcount: 1,
+    cancelStatus: true,
+    reservationState: 'loading',
+  },
+  {
+    id: 3,
+    sittername: '유동혁',
+    reservationStartDate: '2021-07-13',
+    reservationEndDate: '2021-07-15',
+    petcount: 3,
+    cancelStatus: true,
+    reservationState: 'passed',
+  },
+  {
+    id: 4,
+    sittername: '이수광',
+    reservationStartDate: '2022-10-20',
+    reservationEndDate: '2022-10-23',
+    petcount: 2,
+    cancelStatus: true,
+    reservationState: 'passed',
+  },
+];
+
+const MyPage = () => {
+  const [isNowReserve, setIsNowReserve] = useState(true);
+  const [reviews, setReviews] = useState(reviewData);
+  const [reserve, setReserve] = useState(reservationData);
+
+  const reserveNow = reserve.filter(
+    state => state.reservationState === 'loading'
+  );
+  const reservePassed = reserve.filter(
+    state => state.reservationState === 'passed'
+  );
+
+  const goDelete = id => {
+    if (window.confirm('리뷰를 삭제하시겠습니까?')) {
+      setReviews(reviews.filter(review => review.id !== id));
+      alert('리뷰가 삭제되었습니다.');
+    }
+  };
+
+  const cancelRes = id => {
+    const reserveIdx = reserve.findIndex(reserve => reserve.id === id);
+    if (reserve[reserveIdx].cancelStatus) {
+      if (window.confirm('예약을 취소 요청하시겠습니까?')) {
+        alert('요청되었습니다.');
+        const newReserve = [...reserve];
+        newReserve[reserveIdx].cancelStatus = false;
+        setReserve(newReserve);
+      }
+    } else {
+      alert('이미 취소요청되었습니다. 변경하시려면 고객센터로 문의바랍니다.');
+    }
+  };
+
+  return (
+    <MyPageWrapper>
+      <MyPageWrapperDiv>
+        <MyPageTitle>예약내역</MyPageTitle>
+        <ReservationState>
+          <StatusBtnWrapper>
+            <StatusNowBtn
+              isNowReserve={isNowReserve}
+              onClick={() => setIsNowReserve(true)}
+            >
+              진행중인 예약
+            </StatusNowBtn>
+            <StatusPassedBtn
+              isNowReserve={isNowReserve}
+              onClick={() => setIsNowReserve(false)}
+            >
+              지난 예약
+            </StatusPassedBtn>
+          </StatusBtnWrapper>
+          {isNowReserve ? (
+            <MyReservation cancelRes={cancelRes} reserveNow={reserveNow} />
+          ) : (
+            <PassedReservation reservePassed={reservePassed} />
+          )}
+        </ReservationState>
+        <MyReviewWrapper>
+          <MyReviewTitle>내가 쓴 리뷰</MyReviewTitle>
+          <ReviewState>
+            {reviews.length === 0 ? (
+              <NoneReview>내가 쓴 리뷰가 없습니다</NoneReview>
+            ) : (
+              reviews.map((review, idx) => (
+                <MyReview
+                  key={idx}
+                  goDelete={() => goDelete(review.id)}
+                  review={review}
+                  setReviews={setReviews}
+                />
+              ))
+            )}
+          </ReviewState>
+        </MyReviewWrapper>
+      </MyPageWrapperDiv>
+    </MyPageWrapper>
+  );
+};
+
+export default MyPage;
+
+const MyPageWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  @media (max-width: 1000px) {
+    width: 100%;
+    margin-bottom: 200px;
+  }
+`;
+
+const MyPageWrapperDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  width: 1000px;
+  min-height: 700px;
+  padding: 40px;
+  @media (max-width: 1000px) {
+    padding: 20px;
+    width: 500px;
+  }
+`;
+
+const MyPageTitle = styled.p`
+  display: block;
+  margin-bottom: 20px;
+  font-size: 30px;
+  padding: 20px 0px;
+  border-bottom: 1px dashed black;
+  @media (max-width: 1000px) {
+    font-size: 20px;
+  }
+`;
+
+const ReservationState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  @media (max-width: 1000px) {
+    width: 500px;
+  }
+`;
+
+const StatusBtnWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+  width: 800px;
+  height: 60px;
+  @media (max-width: 1000px) {
+    width: 400px;
+  }
+`;
+
+const StatusNowBtn = styled.button`
+  width: 400px;
+  height: 50px;
+  border-style: none;
+  background-color: white;
+  font-size: 20px;
+  padding-bottom: 10px;
+  border-bottom: ${props =>
+    props.isNowReserve ? '1px solid blue' : '1px solid white'};
+  cursor: pointer;
+  @media (max-width: 1000px) {
+    font-size: 18px;
+  }
+`;
+
+const StatusPassedBtn = styled(StatusNowBtn)`
+  border-bottom: ${props =>
+    props.isNowReserve ? '1px solid white' : '1px solid blue'};
+`;
+
+const MyReviewWrapper = styled.div`
+  margin-top: 50px;
+  width: 100%;
+`;
+
+const MyReviewTitle = styled.div`
+  width: 100%;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  font-size: 30px;
+  padding: 20px 0px;
+  border-bottom: 1px dashed black;
+  @media (max-width: 1000px) {
+    font-size: 20px;
+  }
+`;
+
+const ReviewState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 50px;
+`;
+
+const NoneReview = styled.p`
+  margin: 50px 0px;
+  font-size: 20px;
+`;

--- a/src/pages/MyPage/MyReservation.js
+++ b/src/pages/MyPage/MyReservation.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const MyReservation = ({ reserveNow, cancelRes }) => {
+  return (
+    <>
+      {reserveNow.length !== 0 ? (
+        reserveNow.map((reserveNows, idx) => (
+          <MyReservationWrapper key={idx}>
+            <ReservationInfoLeft>
+              <SitterName>{reserveNows.sittername} 펫시터님</SitterName>
+              <ReservationDate>
+                {reserveNows.reservationStartDate}부터{' '}
+                {reserveNows.reservationEndDate}까지
+              </ReservationDate>
+              <ReservationCount>
+                소형견 {reserveNows.petcount}마리
+              </ReservationCount>
+            </ReservationInfoLeft>
+            <ReservationInfoRight>
+              {reserveNows.cancelStatus ? (
+                <ReservationStatus cancelStatus={reserveNows.cancelStatus}>
+                  요청 중
+                </ReservationStatus>
+              ) : (
+                <ReservationStatus cancelStatus={reserveNows.cancelStatus}>
+                  취소 확인 중
+                </ReservationStatus>
+              )}
+              <CancelReservation
+                cancelStatus={reserveNows.cancelStatus}
+                onClick={() => cancelRes(reserveNows.id)}
+              >
+                요청 취소
+              </CancelReservation>
+            </ReservationInfoRight>
+          </MyReservationWrapper>
+        ))
+      ) : (
+        <NonePassedReservation>예약 내역이 없습니다.</NonePassedReservation>
+      )}
+    </>
+  );
+};
+
+export default MyReservation;
+
+const NonePassedReservation = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 80px;
+  margin-bottom: 20px;
+  font-size: 20px;
+  @media (max-width: 1000px) {
+    width: 450px;
+  }
+`;
+
+const MyReservationWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 80%;
+  height: 80px;
+  margin-bottom: 20px;
+  padding: 0px 10px;
+  border: 1px solid #509bff80;
+  border-radius: 5px;
+  @media (max-width: 1000px) {
+    padding: 10px 10px;
+    width: 450px;
+  }
+`;
+
+const ReservationInfoLeft = styled.div`
+  display: flex;
+  justify-content: space-between;
+  @media (max-width: 1000px) {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-top: 3%;
+  }
+`;
+
+const SitterName = styled.p`
+  margin-left: 20px;
+  font-size: 15px;
+  @media (max-width: 1000px) {
+    font-size: 13px;
+    margin-bottom: 8px;
+  }
+`;
+const ReservationDate = styled(SitterName)``;
+const ReservationCount = styled(SitterName)``;
+
+const ReservationInfoRight = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  @media (max-width: 1000px) {
+  }
+`;
+
+const ReservationStatus = styled.p`
+  margin-right: 20px;
+  color: ${props => (props.cancelStatus ? 'black' : 'red')};
+  @media (max-width: 1000px) {
+    font-size: 13px;
+  }
+`;
+
+const CancelReservation = styled.button`
+  border-style: none;
+  width: 100px;
+  height: 40px;
+  color: white;
+  background-color: #509bff;
+  opacity: ${props => (props.cancelStatus ? '1' : '0.5')};
+  border-radius: 5px;
+  cursor: pointer;
+  @media (max-width: 1000px) {
+    width: 70px;
+    font-size: 12px;
+  }
+`;

--- a/src/pages/MyPage/MyReview.js
+++ b/src/pages/MyPage/MyReview.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const MyReview = ({ review, goDelete }) => {
+  const { text, date, sitter } = review;
+
+  const reviewMonth = (new Date(date).getMonth() + 1).toString();
+  const reviewDate = new Date(date).getDate().toString();
+  const reviewHour = new Date(date).getHours().toString();
+  const reviewMinute = new Date(date).getMinutes().toString();
+
+  return (
+    <MyReviewWrapper>
+      <MyReviewLeft>
+        <ReviewSitterName>{sitter} 펫시터님</ReviewSitterName>
+        <ReviewContent>{text}</ReviewContent>
+      </MyReviewLeft>
+      <MyReviewRight>
+        <ReviewTime>
+          {reviewMonth}월 {reviewDate}일 {reviewHour}시 {reviewMinute}분
+        </ReviewTime>
+        <ReviewDelete onClick={goDelete}>삭제</ReviewDelete>
+      </MyReviewRight>
+    </MyReviewWrapper>
+  );
+};
+
+export default MyReview;
+
+const MyReviewWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 10px;
+  padding: 0px 50px;
+  border: 1px solid #509bff80;
+  border-radius: 5px;
+  width: 100%;
+  min-height: 80px;
+  @media (max-width: 1000px) {
+    width: 450px;
+    padding: 0px 10px;
+    margin-bottom: 20px;
+  }
+`;
+
+const MyReviewLeft = styled.div`
+  display: flex;
+  width: 70%;
+  justify-content: space-around;
+  align-items: center;
+  padding: 20px;
+  @media (max-width: 1000px) {
+    flex-direction: column;
+    padding: 10px;
+    width: 300px;
+    align-items: start;
+    justify-content: center;
+    width: 50%;
+  }
+`;
+
+const ReviewSitterName = styled.p`
+  display: flex;
+  justify-content: center;
+  width: 200px;
+  margin-right: 20px;
+  text-align: right;
+  @media (max-width: 1000px) {
+    width: 100px;
+    font-size: 14px;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+    border-bottom: 0.5px solid blue;
+  }
+`;
+
+const ReviewContent = styled.p`
+  margin-right: 10px;
+  font-size: 15px;
+  width: 500px;
+  line-height: 1.5;
+  @media (max-width: 1000px) {
+    width: 100%;
+    white-space: normal;
+  }
+`;
+
+const MyReviewRight = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 40%;
+  @media (max-width: 1000px) {
+    width: 40%;
+  }
+`;
+
+const ReviewTime = styled.p`
+  margin-right: 10px;
+  font-size: 15px;
+  @media (max-width: 1000px) {
+    font-size: 13px;
+  }
+`;
+const ReviewDelete = styled.button`
+  border-style: none;
+  background-color: white;
+  color: red;
+  font-size: 15px;
+  margin-right: 10px;
+  cursor: pointer;
+`;

--- a/src/pages/MyPage/PassedReservation.js
+++ b/src/pages/MyPage/PassedReservation.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const PassedReservation = ({ reservePassed }) => {
+  return (
+    <>
+      {reservePassed.length !== 0 ? (
+        reservePassed.map((passedReserve, idx) => (
+          <MyReservationWrapper key={idx}>
+            <ReservationInfo>
+              <ReservationInfoLeft>
+                <SitterName>{passedReserve.sittername} 펫시터님</SitterName>
+                <ReservationDate>
+                  {passedReserve.reservationStartDate}부터{' '}
+                  {passedReserve.reservationEndDate}까지
+                </ReservationDate>
+              </ReservationInfoLeft>
+              <ReservationCount>
+                소형견 {passedReserve.petcount}마리
+              </ReservationCount>
+            </ReservationInfo>
+          </MyReservationWrapper>
+        ))
+      ) : (
+        <PassedReservationWrapper>
+          <NonePassedReservation>
+            지난 예약 내역이 없습니다.
+          </NonePassedReservation>
+        </PassedReservationWrapper>
+      )}
+    </>
+  );
+};
+
+export default PassedReservation;
+
+const PassedReservationWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+  width: 50%;
+`;
+
+const NonePassedReservation = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 80px;
+  font-size: 20px;
+`;
+
+const MyReservationWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 80%;
+  height: 80px;
+  margin-bottom: 20px;
+  padding: 0px 50px;
+  border: 1px solid #509bff80;
+  border-radius: 5px;
+  opacity: 0.5;
+  @media (max-width: 1000px) {
+    justify-content: space-around;
+    width: 450px;
+    padding: 0px 10px;
+  }
+`;
+
+const ReservationInfo = styled.div`
+  display: flex;
+  @media (max-width: 1000px) {
+    margin-bottom: 5px;
+    align-items: center;
+  }
+`;
+
+const ReservationInfoLeft = styled.div`
+  display: flex;
+  @media (max-width: 1000px) {
+    display: block;
+  }
+`;
+
+const SitterName = styled.p`
+  margin-left: 20px;
+  font-size: 17px;
+  @media (max-width: 1000px) {
+    margin-bottom: 10px;
+    font-size: 16px;
+  }
+`;
+const ReservationDate = styled(SitterName)``;
+const ReservationCount = styled(SitterName)``;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 유저의 예약 내역 및 리뷰 작성 목록을 한 눈에 알아볼 수 있도 UI 구현
- 예약에 따라 취소 요청 가능
- 작성했던 리뷰 삭제 기능

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 예약 내역 관리
- 예약 내역을 현재 진행 중인 예약과 날짜가 지나간 예약으로 분리
- 진행 중인 예약에서는 요청을 취소 할 수 있는 버튼을 구현
- 한번 요청 취소가 들어간 예약에 관해서는 alert 기능으로 더 이상 변경이 불가하고, 고객센터 연락으로 유도함

2. 리뷰 관리 기능
- 목데이터로 리뷰에 관한 데이터를 받아와 props로 뿌려준다.
- 리뷰마다 아이디값을 부여, 같은 아이디를 찾아 해당하는 아이디의 리뷰만 삭제한다.

<br />

## :: 성장 포인트 
- styled 컴포넌트를 좀 더 유용하게 사용할 수 있도록 되었습니다. 조건부에 따라 css를 변경할 수 있게 되었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
